### PR TITLE
Use MIX rpc as fallback url

### DIFF
--- a/src/adapters/web3/init.js
+++ b/src/adapters/web3/init.js
@@ -1,4 +1,5 @@
 import pkg from 'web3';
+import { fallbackUrl } from '@/constants';
 
 let web3;
 
@@ -8,7 +9,12 @@ export function getWeb3Instance() {
 
 export function initializeWeb3(browser = window, Web3 = pkg) {
   if (!web3) {
-    const currentProvider = browser.web3.currentProvider;
-    web3 = new Web3(currentProvider);
+    let provider;
+    if (browser.web3) {
+      provider = browser.web3.currentProvider;
+    } else {
+      provider = new Web3.providers.HttpProvider(fallbackUrl)
+    }
+    web3 = new Web3(provider);
   }
 }

--- a/src/adapters/web3/init.js
+++ b/src/adapters/web3/init.js
@@ -2,6 +2,7 @@ import pkg from 'web3';
 import { fallbackUrl } from '@/constants';
 
 let web3;
+let isUsingFallback = false;
 
 export function getWeb3Instance() {
   return web3;
@@ -14,11 +15,17 @@ export function initializeWeb3(browser = window, Web3 = pkg) {
       provider = browser.web3.currentProvider;
     } else {
       provider = new Web3.providers.HttpProvider(fallbackUrl)
+      isUsingFallback = true;
     }
     web3 = new Web3(provider);
   }
 }
 
 export function resetWeb3Instance() {
+  isUsingFallback = false;
   web3 = undefined;
+}
+
+export function getIsUsingFallback() {
+  return isUsingFallback;
 }

--- a/src/adapters/web3/init.js
+++ b/src/adapters/web3/init.js
@@ -10,11 +10,15 @@ export function getWeb3Instance() {
 export function initializeWeb3(browser = window, Web3 = pkg) {
   if (!web3) {
     let provider;
-    if (browser.web3) {
+    if (browser.web3 && browser.web3.currentProvider) {
       provider = browser.web3.currentProvider;
     } else {
       provider = new Web3.providers.HttpProvider(fallbackUrl)
     }
     web3 = new Web3(provider);
   }
+}
+
+export function resetWeb3Instance() {
+  web3 = undefined;
 }

--- a/src/adapters/web3/init.test.js
+++ b/src/adapters/web3/init.test.js
@@ -19,6 +19,10 @@ describe('adapters/web3/init', () => {
   });
 
   describe('initializeWeb3', () => {
+    beforeEach(() => {
+      web3.resetWeb3Instance();
+    });
+
     it('should initialize web3 from the current provider', () => {
       const mockWindow = {
         web3: {
@@ -34,6 +38,56 @@ describe('adapters/web3/init', () => {
       web3.initializeWeb3(mockWindow, mockPackage);
 
       expect(mockConstructor).toBeCalledWith('testProvider');
+    });
+
+    it('should use the httpProivder is web3 is not available', () => {
+      const mockWindow = {};
+      const mockWeb3Constructor = jest.fn();
+      const mockHPConstructor = jest.fn();
+      class mockPackage {
+        constructor(provider) {
+          mockWeb3Constructor(provider);
+        }
+      }
+      class mockHttpProvider {
+        constructor(url) {
+          mockHPConstructor(url);
+        }
+      }
+      mockPackage.providers = {
+        HttpProvider: mockHttpProvider,
+      };
+      web3.initializeWeb3(mockWindow, mockPackage);
+
+      expect(mockHPConstructor).toBeCalled();
+      expect(mockWeb3Constructor).toBeCalled();
+    });
+  });
+
+
+  describe('resetWeb3Instance', () => {
+    it('should reset the current web3 instance', () => {
+      const mockWindow = {
+        web3: {
+          currentProvider: 'testProvider',
+        },
+      };
+      const mockConstructor = jest.fn();
+      class mockPackage {
+        constructor(provider) {
+          mockConstructor(provider);
+        }
+      }
+      web3.resetWeb3Instance();
+      web3.initializeWeb3(mockWindow, mockPackage);
+
+      const instance1 = web3.getWeb3Instance();
+      expect(instance1).toEqual({});
+
+      web3.resetWeb3Instance();
+
+      const instance2 = web3.getWeb3Instance();
+      expect(instance2).toBe(undefined);
     });
   });
 });

--- a/src/adapters/web3/init.test.js
+++ b/src/adapters/web3/init.test.js
@@ -40,7 +40,7 @@ describe('adapters/web3/init', () => {
       expect(mockConstructor).toBeCalledWith('testProvider');
     });
 
-    it('should use the httpProivder is web3 is not available', () => {
+    it('should use the httpProivder if web3 is not available', () => {
       const mockWindow = {};
       const mockWeb3Constructor = jest.fn();
       const mockHPConstructor = jest.fn();
@@ -115,7 +115,7 @@ describe('adapters/web3/init', () => {
       expect(isUsingFallback).toBe(false);
     });
 
-    it('should return true for web3 does not exist the browser', () => {
+    it('should return true if web3 does not exist the browser', () => {
       const mockWindow = {};
       const mockWeb3Constructor = jest.fn();
       const mockHPConstructor = jest.fn();

--- a/src/adapters/web3/init.test.js
+++ b/src/adapters/web3/init.test.js
@@ -90,4 +90,53 @@ describe('adapters/web3/init', () => {
       expect(instance2).toBe(undefined);
     });
   });
+
+  describe('getIsUsingWeb3', () => {
+    beforeEach(() => {
+      web3.resetWeb3Instance();
+    });
+
+    it('should return false if web3 exists in the browser', () => {
+      const mockWindow = {
+        web3: {
+          currentProvider: 'testProvider',
+        },
+      };
+      const mockConstructor = jest.fn();
+      class mockPackage {
+        constructor(provider) {
+          mockConstructor(provider);
+        }
+      }
+      web3.initializeWeb3(mockWindow, mockPackage);
+
+      const isUsingFallback = web3.getIsUsingFallback();
+
+      expect(isUsingFallback).toBe(false);
+    });
+
+    it('should return true for web3 does not exist the browser', () => {
+      const mockWindow = {};
+      const mockWeb3Constructor = jest.fn();
+      const mockHPConstructor = jest.fn();
+      class mockPackage {
+        constructor() {
+          mockWeb3Constructor();
+        }
+      }
+      class mockHttpProvider {
+        constructor() {
+          mockHPConstructor();
+        }
+      }
+      mockPackage.providers = {
+        HttpProvider: mockHttpProvider,
+      };
+      web3.initializeWeb3(mockWindow, mockPackage);
+
+      const isUsingFallback = web3.getIsUsingFallback();
+
+      expect(isUsingFallback).toBe(true);
+    });
+  });
 });

--- a/src/adapters/web3/transactions.test.js
+++ b/src/adapters/web3/transactions.test.js
@@ -35,7 +35,7 @@ describe('adapters/web3/transactions', () => {
       mockEth.getTransaction = mockCallback;
 
       const mockHashes = ['0x2', '0x5', '0x10'];
-      const expectedTransactions = ['B0x2', 'B0x5', 'B0x10'];
+      const expectedTransactions = ['B0x2', 'B0x10'];
       const transactions = await web3.getTransactions(mockHashes, mockGetInstance);
 
       expect(transactions).toEqual(expectedTransactions);

--- a/src/components/Start.js
+++ b/src/components/Start.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import { getIsUsingFallback } from '@/adapters/web3/init';
 import { getLatestBlocksForDisplay } from '@/reducers/selectors';
 
 import BlockTable from './BlockTable';
@@ -13,6 +14,10 @@ const mapStateToProps = (state) => ({
 const Start = ({ blocks = [] }) => (
   <div>
     <h2>Welcome!</h2>
+    Connected to {getIsUsingFallback()
+      ? 'MIX (rpc.mix-blockchain.org)'
+      : 'your Web3 browser extension (e.g. Metamask)'
+    }
     <BlockTable blocks={blocks} title='Latest Blocks' />
   </div>
 );

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
+export const fallbackUrl = 'https://rpc.mix-blockchain.org:8647';
 export const maxBlocksPerPage = 10;
 
 export const tableFields = {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,4 +1,4 @@
-export const fallbackUrl = 'http://172.105.237.231:8645';
+export const fallbackUrl = 'http://rpc.mix-blockchain.org:8645';
 export const maxBlocksPerPage = 10;
 
 export const tableFields = {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,4 +1,4 @@
-export const fallbackUrl = 'https://rpc.mix-blockchain.org:8647';
+export const fallbackUrl = 'http://172.105.237.231:8645';
 export const maxBlocksPerPage = 10;
 
 export const tableFields = {


### PR DESCRIPTION
@ethernomad We can't test this at the moment because of the CORS configuration on the `rpc.mix-blockchain.org` server. Could you allow `localhost` for development purposes?