### PR TITLE
redux first router

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
-    "redux-first-router": "^0.0.16-next",
+    "redux-first-router": "^1.9.19",
     "redux-first-router-link": "^1.4.2",
     "sass-loader": "^6.0.6",
     "style-loader": "0.19.0",

--- a/src/actions/redirect/creators.js
+++ b/src/actions/redirect/creators.js
@@ -10,8 +10,7 @@ export function redirectAccountDetail(address) {
   return redirect({
     type: routes.ACCOUNT_DETAIL,
     payload: {
-      // redux-first-router has issues with '0x' strings
-      address: `_${address}`,
+      address,
     },
   });
 }
@@ -29,8 +28,7 @@ export function redirectTransactionDetail(hash) {
   return redirect({
     type: routes.TRANSACTION_DETAIL,
     payload: {
-      // redux-first-router has issues with '0x' strings
-      hash: `_${hash}`,
+      hash,
     },
   });
 }

--- a/src/components/Block.js
+++ b/src/components/Block.js
@@ -35,7 +35,7 @@ const Block = ({ block = {} }) => (
         name='Mined by'
         value={<Link to={{
           type: routes.ACCOUNT_DETAIL,
-          payload: { address: `_${block.miner}` },
+          payload: { address: block.miner },
         }}>{block.miner}</Link>}
       />
       <DetailListItem name='Gas Limit' value={block.gasLimit} />

--- a/src/components/Transaction.js
+++ b/src/components/Transaction.js
@@ -33,14 +33,14 @@ const Transaction = ({ transaction }) => (
         name='Sender'
         value={<Link to={{
           type: routes.ACCOUNT_DETAIL,
-          payload: { address: `_${transaction.from}` }
+          payload: { address: transaction.from }
         }}>{transaction.from}</Link>}
       />
       <DetailListItem
         name='Receiver'
         value={<Link to={{
           type: routes.ACCOUNT_DETAIL,
-          payload: { address: `_${transaction.to}` }
+          payload: { address: transaction.to }
         }}>{transaction.to}</Link>}
       />
     </DetailList>

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -20,9 +20,7 @@ export function getAccount(state, address) {
 }
 
 export function getCurrentAccountForDisplay(state, methods = { getAccount, fromWei }) {
-  // redux-first-router has issues with '0x' strings
-  const locationAddress = state.location.payload.address || '';
-  const address = locationAddress.replace('_', '');
+  const address = state.location.payload.address || '';
   const accountData = methods.getAccount(state, address);
   let balanceInWei = 0;
   let balanceInEther = 0;

--- a/src/reducers/blocks.js
+++ b/src/reducers/blocks.js
@@ -64,8 +64,7 @@ export function getLatestBlocksForDisplay(state, amountOfBlocks, methods = { get
       miner: {
         value: block.miner,
         linkType: routes.ACCOUNT_DETAIL,
-        // redux-first-router has issues with '0x' strings
-        linkPayload: { address: `_${block.miner}` },
+        linkPayload: { address: block.miner },
       },
     };
     blocksForDisplay.push(displayBlock);

--- a/src/reducers/transactions.js
+++ b/src/reducers/transactions.js
@@ -65,7 +65,7 @@ export function getTransactionsForDisplay(state, hashes, methods = { getSingleTr
         hash: {
           value: hash,
           linkType: routes.TRANSACTION_DETAIL,
-          linkPayload: { hash: `_${hash}` },
+          linkPayload: { hash },
         },
         amount: {
           value: `${value} Ether`,

--- a/src/router/thunks.js
+++ b/src/router/thunks.js
@@ -2,10 +2,7 @@ import * as actions from '@/actions/creators';
 import * as selectors from '@/reducers/selectors';
 
 export function fetchAccount(dispatch, getState) {
-  const addressLocation = getState().location.payload.address || '';
-  // redux-first-router has issues with '0x' strings
-  const address = addressLocation.replace('_', '');
-
+  const address = getState().location.payload.address || '';
   dispatch(actions.fetchAccount(address));
 }
 
@@ -33,9 +30,7 @@ export function fetchTransactions(dispatch, getState) {
 }
 
 export function fetchSingleTransaction(dispatch, getState) {
-  const hashLocation = getState().location.payload.hash || '';
-  // redux-first-router has issues with '0x' strings
-  const hash = hashLocation.replace('_', '');
+  const hash = getState().location.payload.hash || '';
   const hashInState = selectors.getTransactionInState(getState(), hash);
 
   if (!hashInState) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5500,11 +5500,11 @@ redux-first-router-link@^1.4.2:
     prop-types "15.5.10"
     rudy-match-path "^0.3.0"
 
-redux-first-router@^0.0.16-next:
-  version "0.0.16-next"
-  resolved "https://registry.yarnpkg.com/redux-first-router/-/redux-first-router-0.0.16-next.tgz#493c344dd92b4c20a318a024d4dfa7d948d87d86"
+redux-first-router@^1.9.19:
+  version "1.9.19"
+  resolved "https://registry.yarnpkg.com/redux-first-router/-/redux-first-router-1.9.19.tgz#6f670e40837efcefdcc117361b9d20628e33c097"
   dependencies:
-    rudy-match-path "^0.3.0"
+    path-to-regexp "^1.7.0"
 
 redux@^3.7.2:
   version "3.7.2"


### PR DESCRIPTION
**Do not merge.**
**Keep up to date**  --> merge new branches into this branch before merging into master.

[redux-first-router](https://github.com/faceyspacey/redux-first-router) is the preferred routing solution. However, until their next major release ("Rudy") [hashes ("0x...") cannot be used in URLs](https://github.com/faceyspacey/redux-first-router/issues/222).

This branch is set up to work with the new release (unless it includes breaking changes) and should be kept up to date so we can switch back to redux-first-router after their release.

master will use [react-router](https://github.com/ReactTraining/react-router) as temporary workaround.